### PR TITLE
fix: italic_comments option affects strings

### DIFF
--- a/lua/lavish/scheme.lua
+++ b/lua/lavish/scheme.lua
@@ -115,7 +115,7 @@ local function fill_default(colors, style)
         SpecialComment = { link = "Special" },
         Statement = { link = "Keyword" },
         StorageClass = { link = "Type" },
-        String = { fg = colors.normal.green, italic = style.italic_comments },
+        String = { fg = colors.normal.green, italic = style.italic_strings },
         Structure = { link = "Type" },
         Tag = { link = "Special" },
         Todo = { fg = colors.normal.red, bold = true },


### PR DESCRIPTION
You seem to have made a typo. I was testing your colorscheme and I found that the `italic_comments` option was affecting the strings as well, so I decided to investigate the reason and I seem to have found it.

Looks like a pretty readable and elegant colorscheme, keep up the hard work!