### PR TITLE
feat: add mini.icons support

### DIFF
--- a/lua/lavish/scheme.lua
+++ b/lua/lavish/scheme.lua
@@ -261,6 +261,17 @@ local function fill_default(colors, style)
         TelescopeNormal = { link = "NormalFloat" },
         TelescopeBorder = { link = "FloatBorder" },
         TelescopePromptCounter = { fg = colors.base.fg3 },
+
+        -- mini.icons
+        MiniIconsAzure = { fg = colors.bright.blue },
+        MiniIconsBlue = { fg = colors.normal.blue },
+        MiniIconsCyan = { fg = colors.normal.cyan },
+        MiniIconsGreen = { fg = colors.normal.green },
+        MiniIconsGrey = { fg = colors.base.fg1 },
+        MiniIconsOrange = { fg = colors.normal.yellow },
+        MiniIconsPurple = { fg = colors.normal.magenta },
+        MiniIconsRed = { fg = colors.normal.red },
+        MiniIconsYellow = { fg = colors.bright.yellow },
     }
 end
 


### PR DESCRIPTION
Adds support for [mini.icons](https://github.com/echasnovski/mini.icons) highlight groups.

It is possible to use this plugin to replace [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons), and so I do. Telescope does not officially support mini.icons, but it is possible to make it work. Here is an example of what it looked like before and what it looks like now:

![before](https://github.com/user-attachments/assets/bec2182d-f45e-4e00-8055-f3dd60914fe5)
![after](https://github.com/user-attachments/assets/0925db3b-2c44-4f2d-a9ee-e6af223b0727)
