### PR TITLE
fix: TabLineSel distinguishable from TabLine

### DIFF
--- a/lua/lavish/scheme.lua
+++ b/lua/lavish/scheme.lua
@@ -70,7 +70,7 @@ local function fill_default(colors, style)
         Substitute = { bg = colors.faint.red },
         TabLine = { link = "StatusLine" },
         TabLineFill = { link = "StatusLine" },
-        TabLineSel = { bg = colors.base.bg4 },
+        TabLineSel = { bg = colors.base.bg1, bold = true },
         TermCursor = { link = "Cursor" },
         TermCursorNC = { fg = colors.base.bg1, bg = colors.base.fg2 },
         Title = { fg = colors.normal.green },


### PR DESCRIPTION
I like this theme, though I noticed that `TablineSel` ended up with the same background as `TabLine`, making it difficult to tell which tab is selected. I added this to my `scheme_overrides`, but thought it should probably be default.

Old highlight (telescope.lua is current file):
![old-tabline](https://github.com/user-attachments/assets/e91acb40-775f-4e46-b9be-c716a2efc8bf)

New highlight:
![new-tabline](https://github.com/user-attachments/assets/7eb6cf57-ef73-47a0-b8a1-151092027f33)

Of course, this is just what I thought looked good. If you want a different color or not bold, I'm happy to change it.

Thanks!