### PR TITLE
feat: add color to tag.attribute, in order to diferentiate props to jsx tags

### DIFF
--- a/lua/lavish/scheme.lua
+++ b/lua/lavish/scheme.lua
@@ -239,7 +239,7 @@ local function fill_default(colors, style)
         ["@diff.delta"] = { link = "Changed" },
         -- ['@tag'] = {},
         -- ['@tag.builtin'] = {},
-        -- ['@tag.attribute'] = {},
+        ['@tag.attribute'] = { link = "Identifier"},
         -- ['@tag.delimiter'] = {},
 
         -- Quickfix list

--- a/lua/lavish/scheme.lua
+++ b/lua/lavish/scheme.lua
@@ -239,7 +239,7 @@ local function fill_default(colors, style)
         ["@diff.delta"] = { link = "Changed" },
         -- ['@tag'] = {},
         -- ['@tag.builtin'] = {},
-        ['@tag.attribute'] = { link = "Identifier"},
+        ['@tag.attribute'] = { link = "Identifier" },
         -- ['@tag.delimiter'] = {},
 
         -- Quickfix list


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/639df2f0-1a29-43c4-8b35-feefb8b6683f)


After:
![image](https://github.com/user-attachments/assets/598f4827-3b61-4a1d-8e33-a0f015fb71a2)
